### PR TITLE
Add Discontinuous Galerkin solver for heat equation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,5 +164,11 @@ cython_debug/
 **/*.h5
 *.vtk
 **/*.vtk
+*.vtu
+**/*.vtu
+*.pvtu
+**/*.pvtu
+*.pvd
+**/*.pvd
 *.xdmf
 **/*.xdmf

--- a/ThermoViscoProblem.py
+++ b/ThermoViscoProblem.py
@@ -525,11 +525,13 @@ class ThermoViscoProblem:
 
             # DG Part of the weak form: additional surface integrals over
             # interior facets
-            # dS: interior facet measure
-            self.F += self.dt * (
-                self.alpha('+')*(penalty('+')/h('+')) * dot(jump(self.v,n),jump(self.T_current,n)) * dS
-                - self.alpha('+')*dot(avg(grad(self.v)), jump(self.T_current, n))*dS
-                - self.alpha('+')*dot(jump(self.v, n), avg(grad(self.T_current)))*dS
+            self.F += self.dt * self.alpha('+')*(
+                # p/h * <[[v]],[[T]]>
+                (penalty('+')/h('+')) * dot(jump(self.v,n),jump(self.T_current,n)) * dS
+                # - <{∇v},[[T·n]]>
+                - dot(avg(grad(self.v)), jump(self.T_current, n))*dS
+                # - <{v·n},[[∇T]]>
+                - dot(jump(self.v, n), avg(grad(self.T_current)))*dS
             )
 
         return

--- a/ThermoViscoProblem.py
+++ b/ThermoViscoProblem.py
@@ -505,7 +505,7 @@ class ThermoViscoProblem:
             (self.T_current - self.T_previous) * self.v * dx
             + self.dt * (
             # Laplacian
-            + self.alpha * dot(grad(self.T_current),grad(self.v)) * dx
+            + self.alpha * inner(grad(self.T_current),grad(self.v)) * dx
             # Right hand side
             - self.f * self.v * dx
             # Radiation
@@ -527,11 +527,11 @@ class ThermoViscoProblem:
             # interior facets
             self.F += self.dt * self.alpha('+')*(
                 # p/h * <[[v]],[[T]]>
-                (penalty('+')/h('+')) * dot(jump(self.v,n),jump(self.T_current,n)) * dS
+                (penalty('+')/h('+')) * inner(jump(self.v,n),jump(self.T_current,n)) * dS
                 # - <{∇v},[[T·n]]>
-                - dot(avg(grad(self.v)), jump(self.T_current, n))*dS
+                - inner(avg(grad(self.v)), jump(self.T_current, n))*dS
                 # - <{v·n},[[∇T]]>
-                - dot(jump(self.v, n), avg(grad(self.T_current)))*dS
+                - inner(jump(self.v, n), avg(grad(self.T_current)))*dS
             )
 
         return

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ if create_new_mesh:
     create_mesh(path=mesh_path)
 
 fe_config = {
-    "T":        {"element": "CG", "degree": 1},
+    "T":        {"element": "DG", "degree": 1},
     "sigma":    {"element": "CG", "degree": 1},
 }
 
@@ -38,7 +38,7 @@ model_params = {
     # Initial temperature
     "T_0": 800.0,
     # Convective heat transfer coefficient
-    "alpha": 0.0005,
+    "alpha": 1.0,
     "htc": 280.1,
     # Material density
     "rho": 2500.0,


### PR DESCRIPTION
This PR adds the option to solve the heat equation with a Symmetric Interior Penalty Discontinuous Galerkin (SIPDG) method.
To do so, one only has to change the dict entry `element` for `T` from `"CG"` to `"DG"`.

While on one processor, solution takes quite a bit longer (~40%), it should scale much better for large problems if they are solved in parallel.

The necessary terms are added to the weak form if a DG element for temperature is created:
https://github.com/PI-UniA/SurroGlas/blob/5857fe628119a1b50cdd358a345d202c17192d12/ThermoViscoProblem.py#L518-L535